### PR TITLE
feat(3d): wireframe 3D view for flat roof (eaves/dashed parapet, L/U/T, OrbitControls)

### DIFF
--- a/activity.log
+++ b/activity.log
@@ -518,6 +518,14 @@
 - 棟側（棟に正面）の四角形上辺・縦辺はeaves端（軒の出を反映した端点）で描くよう修正（台形化を解消）（src/components/ElevationView.tsx）
 2025-09-20: 棟側で軒先端と壁頂点を“水平”に接続
 - 四角形下辺（壁上端）の上で、壁端→軒先端への水平点線コネクタを追加（src/components/ElevationView.tsx）
+
+2025-09-20: 3D操作性の改善（回転/パン/ズーム）
+- OrbitControlsへ切替（左ドラッグ=回転、右ドラッグ=パン、中/ピンチ/ホイール=ズーム）
+- Shift+ホイールでパン（既定はズーム）、panByPixelsで自然な移動量（src/components/Wireframe3D.tsx）
+
+2025-09-20: パラペット下端の接続を自然に
+- 軒の出オフセット外周に沿ってパラペット下端リング（wallTop）も点線で連続描画
+- 余分な補助コネクタを撤去し、上下リング＋端点の垂直で整った接続に（src/core/wireframe-3d.ts）
 2025-09-20: 片流れの立面表現を強化
 - 棟側は切妻と同様に四角形（点線）。壁端→軒先端の水平コネクタも追加
 - 片流れ面（勾配が見える側）は、三角形（点線）の斜辺を描画し、高い側の壁ラインを上へ延長（実線）（src/components/ElevationView.tsx）
@@ -566,3 +574,30 @@
 - 高い向き=downhillの反対、画面左の方角（北=東/南=西/東=南/西=北）との一致で apexOnLeft を決定（src/components/ElevationView.tsx）
 2025-09-20: 立面表示の緊急安定化（斜辺分割を一旦停止）
 - gable/hip/mono の斜辺分割を撤回し、従来の描画に戻して全方向の破綻を解消（src/components/ElevationView.tsx）
+2025-09-20: フェーズ4 3D線画（矩形フラット屋根）最小実装
+- ブランチ作成（feat/phase4-3d-wireframe-flat-roof）
+- 3Dワイヤーフレーム生成ロジック追加（src/core/wireframe-3d.ts）
+- Wireframe3Dコンポーネント追加（COLORS.wall 準拠の線色）
+- 3DビューをWireframe3Dに差し替え（src/app/page.tsx）
+  
+2025-09-20: L/U/T形状対応（3D線画の可視差向上）
+- フロア別に線分を生成し色分け描画（src/components/Wireframe3D.tsx）
+- L/U/T 形状の外周をそのままプリズム化して3D線画表示
+
+2025-09-20: フラット屋根の立上りを点線化
+- パラペット立上り（壁上端→パラペット上端）を LineDashedMaterial で描画
+- 実線/点線を分離生成（src/core/wireframe-3d.ts）、3D描画更新（src/components/Wireframe3D.tsx）
+
+2025-09-20: 天井ライン=実線・パラペット=点線に統一
+- 天井（壁上端の水平リング）を常に実線化、パラペット上端水平リングを点線化
+- buildFlatRoofWireStyledFromFloor の線種分離を更新（src/core/wireframe-3d.ts）
+
+2025-09-20: 3Dの軒の出対応（フラット）
+- パラペット上端リングと立上りを軒の出オフセット外周に沿って描画
+- バウンディング計算を実線+点線の合成に変更（src/components/Wireframe3D.tsx）
+
+2025-09-20: 壁頂点と軒先端を結ぶ点線コネクタ
+- 天井高さの壁頂点→軒の出先端（パラペット上端）を斜め点線で結ぶ（src/core/wireframe-3d.ts）
+
+2025-09-20: 立面図同様の結び方に修正
+- 斜めコネクタを廃止し、天井高さでの水平点線 + 軒先垂直点線のL字結線へ変更（src/core/wireframe-3d.ts）

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import ElevationView from '@/components/ElevationView'
 import { createFloor, duplicateFloor, FloorState, randomId, nextFloorName, cloneShape, createDefaultShape } from '@/core/floors'
 import { pickFloorColorsByName } from '@/ui/palette'
 import type { TemplateKind } from '@/core/model'
-import ThreePlaceholder from '@/components/ThreePlaceholder'
+import Wireframe3D from '@/components/Wireframe3D'
 import { SNAP_DEFAULTS } from '@/core/snap'
 import { downloadJson, loadFromLocalStorage, parseSaveData, saveToLocalStorage, serializeSaveData, clearLocalStorage, persistFloorToState } from '@/io/persist'
 import type { RoofUnit } from '@/core/roofing'
@@ -319,7 +319,7 @@ export default function Page() {
           {view === 'elev' && (
             <ElevationView floors={floors.filter(f => f.visible)} />
           )}
-          {view === '3d' && <ThreePlaceholder />}
+          {view === '3d' && <Wireframe3D floors={floors.filter(f => f.visible)} />}
         </main>
       </div>
       {previewOpen && (

--- a/src/components/Wireframe3D.tsx
+++ b/src/components/Wireframe3D.tsx
@@ -1,0 +1,195 @@
+"use client";
+// 日本語コメント: 平面図から得た情報（フロア形状と高さ、フラット屋根のパラペット）で3D線画を生成
+import React, { useEffect, useMemo, useRef } from 'react'
+import * as THREE from 'three'
+// @ts-ignore: 型定義は three の examples に含まれるが環境差異を吸収
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import type { FloorState } from '@/core/floors'
+import { buildFlatRoofWireFromFloor, buildFlatRoofWireStyledFromFloor, mmToM, bboxOfSegments } from '@/core/wireframe-3d'
+import { COLORS } from '@/ui/colors'
+
+const toThreeColor = (hex: string) => new THREE.Color(hex)
+
+const Wireframe3D: React.FC<{ floors: FloorState[] }> = ({ floors }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  // 日本語コメント: 可視な階のみを対象にワイヤーフレーム線分を集約
+  const floorSegments = useMemo(() => {
+    return floors.filter(f => f.visible).map(f => ({
+      floor: f,
+      all: buildFlatRoofWireFromFloor(f),
+      styled: buildFlatRoofWireStyledFromFloor(f)
+    }))
+  }, [floors])
+
+  useEffect(() => {
+    const el = containerRef.current!
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color('#0f1113')
+
+    // 日本語コメント: 適度に俯瞰する視点（透視）。対象に合わせて距離を自動調整
+    const camera = new THREE.PerspectiveCamera(60, 1, 0.01, 1000)
+    const renderer = new THREE.WebGLRenderer({ antialias: true })
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+    renderer.setSize(el.clientWidth, el.clientHeight)
+    el.appendChild(renderer.domElement)
+
+    // 日本語コメント: フロアごとに線分を作成（色は各フロアの壁色、無指定時は COLORS.wall）
+    const group = new THREE.Group()
+    const geoms: THREE.BufferGeometry[] = []
+    const mats: (THREE.LineBasicMaterial | THREE.LineDashedMaterial)[] = []
+    for (const entry of floorSegments) {
+      const color = entry.floor.color?.walls ?? COLORS.wall
+      // 実線
+      const positions: number[] = []
+      for (const s of entry.styled.solid) {
+        positions.push(mmToM(s.a.x), mmToM(s.a.z), mmToM(s.a.y))
+        positions.push(mmToM(s.b.x), mmToM(s.b.z), mmToM(s.b.y))
+      }
+      const geom = new THREE.BufferGeometry()
+      geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3))
+      const mat = new THREE.LineBasicMaterial({ color: toThreeColor(color) })
+      const lines = new THREE.LineSegments(geom, mat)
+      group.add(lines)
+      geoms.push(geom); mats.push(mat)
+
+      // 点線（パラペット立ち上がり）
+      if (entry.styled.dashed.length) {
+        const dpos: number[] = []
+        for (const s of entry.styled.dashed) {
+          dpos.push(mmToM(s.a.x), mmToM(s.a.z), mmToM(s.a.y))
+          dpos.push(mmToM(s.b.x), mmToM(s.b.z), mmToM(s.b.y))
+        }
+        const dgeom = new THREE.BufferGeometry()
+        dgeom.setAttribute('position', new THREE.Float32BufferAttribute(dpos, 3))
+        const dmat = new THREE.LineDashedMaterial({ color: toThreeColor(color), dashSize: 0.15, gapSize: 0.1 })
+        const dlines = new THREE.LineSegments(dgeom, dmat)
+        // ダッシュ有効化のため距離属性を計算
+        // @ts-ignore threeの型ではLineSegmentsにもcomputeLineDistancesあり
+        dlines.computeLineDistances?.()
+        group.add(dlines)
+        geoms.push(dgeom); mats.push(dmat)
+      }
+    }
+    scene.add(group)
+
+    // 日本語コメント: 対象のバウンディングからカメラ距離を算出して全体が収まるように調整
+    // バウンディングは実線+点線すべてを対象に算出
+    const bb = bboxOfSegments(floorSegments.flatMap(f => [...f.styled.solid, ...f.styled.dashed]))
+    let target = new THREE.Vector3(0, 0, 0)
+    if (bb) {
+      const sizeX = mmToM(bb.max.x - bb.min.x)
+      const sizeZ = mmToM(bb.max.z - bb.min.z)
+      const sizeY = mmToM(bb.max.y - bb.min.y) // 現状Yは0だが将来拡張に備える
+      const radius = Math.max(0.5, Math.max(sizeX, sizeZ) * 0.75)
+      const center = new THREE.Vector3(
+        mmToM((bb.min.x + bb.max.x) / 2),
+        mmToM((bb.min.y + bb.max.y) / 2),
+        mmToM((bb.min.z + bb.max.z) / 2),
+      )
+      group.position.set(-center.x, -center.y, -center.z)
+      target = new THREE.Vector3(0, 0, 0)
+      const dist = radius / Math.tan((camera.fov * Math.PI / 180) / 2)
+      camera.position.set(dist * 0.9, dist * 0.7, dist * 0.9)
+      camera.lookAt(0, 0, 0)
+    } else {
+      camera.position.set(3, 2, 3)
+      camera.lookAt(0, 0, 0)
+    }
+
+    // 環境光（線色には影響しないが多少の視認性向上）
+    const light = new THREE.AmbientLight(0xffffff, 0.6)
+    scene.add(light)
+
+    // 日本語コメント: インタラクション（回転/パン/ズーム）— OrbitControls を採用
+    const controls = new OrbitControls(camera, renderer.domElement)
+    controls.enableDamping = true
+    controls.dampingFactor = 0.08
+    controls.enableRotate = true
+    controls.screenSpacePanning = true
+    controls.enablePan = true
+    controls.enableZoom = true
+    controls.mouseButtons = {
+      LEFT: THREE.MOUSE.ROTATE,
+      MIDDLE: THREE.MOUSE.DOLLY,
+      RIGHT: THREE.MOUSE.PAN,
+    }
+    controls.target.copy(target)
+    controls.update()
+
+    // 内部 pan 実装（OrbitControlsのロジックに追随）
+    const panOffset = new THREE.Vector3()
+    const panLeft = (distance: number, objectMatrix: THREE.Matrix4) => {
+      const v = new THREE.Vector3().setFromMatrixColumn(objectMatrix, 0)
+      v.multiplyScalar(-distance)
+      panOffset.add(v)
+    }
+    const panUp = (distance: number, objectMatrix: THREE.Matrix4) => {
+      const v = new THREE.Vector3()
+      if ((controls as any).screenSpacePanning === true) {
+        v.setFromMatrixColumn(objectMatrix, 1)
+      } else {
+        v.setFromMatrixColumn(objectMatrix, 0)
+        v.crossVectors((camera as any).up, v)
+      }
+      v.multiplyScalar(distance)
+      panOffset.add(v)
+    }
+    const panByPixels = (deltaX: number, deltaY: number) => {
+      // パースペクティブ時: 目標点距離とFOVからピクセル→ワールド換算
+      const offset = new THREE.Vector3().copy(camera.position).sub(controls.target)
+      let targetDistance = offset.length()
+      targetDistance *= Math.tan((camera.fov / 2) * Math.PI / 180)
+      const moveLeft = (2 * deltaX * targetDistance) / Math.max(1, el.clientHeight)
+      const moveUp = (2 * deltaY * targetDistance) / Math.max(1, el.clientHeight)
+      camera.updateMatrix()
+      panLeft(moveLeft, camera.matrix)
+      panUp(moveUp, camera.matrix)
+      camera.position.add(panOffset)
+      controls.target.add(panOffset)
+      panOffset.set(0, 0, 0)
+    }
+    // スクロール（ホイール）: 既定=ズーム（OrbitControls）、Shift+ホイール=パン
+    const onWheel = (ev: WheelEvent) => {
+      if (!ev.shiftKey) return // OrbitControls に任せてズーム
+      ev.preventDefault()
+      panByPixels(ev.deltaX, ev.deltaY)
+      controls.update()
+      renderer.render(scene, camera)
+    }
+    renderer.domElement.addEventListener('wheel', onWheel, { passive: false })
+
+    // レンダリングループ（軽量、コントロールのダンピングでアニメ）
+    let raf = 0
+    const animate = () => {
+      controls.update()
+      renderer.render(scene, camera)
+      raf = requestAnimationFrame(animate)
+    }
+    animate()
+
+    const onResize = () => {
+      const w = el.clientWidth
+      const h = el.clientHeight
+      renderer.setSize(w, h)
+      camera.aspect = w / h
+      camera.updateProjectionMatrix()
+    }
+    const ro = new ResizeObserver(onResize)
+    ro.observe(el)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      ro.disconnect()
+      renderer.domElement.removeEventListener('wheel', onWheel as any)
+      geoms.forEach(g => g.dispose())
+      mats.forEach(m => m.dispose())
+      renderer.dispose()
+      if (renderer.domElement?.parentNode === el) el.removeChild(renderer.domElement)
+    }
+  }, [floorSegments])
+
+  return <div ref={containerRef} className="w-full h-full" style={{ touchAction: 'none' }} />
+}
+
+export default Wireframe3D

--- a/src/core/wireframe-3d.ts
+++ b/src/core/wireframe-3d.ts
@@ -1,0 +1,134 @@
+// 日本語コメント: 平面図（2Dポリゴン）から矩形フラット屋根の3Dワイヤーフレーム（線分群）を生成する最小ロジック
+import type { FloorState } from '@/core/floors'
+import type { Vec2 } from '@/core/units'
+import { outlineRect, outlineL, outlineU, outlineT, outlinePoly, type TemplateKind } from '@/core/model'
+import { applyEavesOffset } from '@/core/roofing'
+import { buildOffsetLines, adjustedSegmentEndpoints } from '@/core/eaves/helpers'
+import { signedArea as signedAreaModel } from '@/core/eaves/offset'
+
+export type Vec3 = { x: number; y: number; z: number }
+
+export type Segment3D = { a: Vec3; b: Vec3 }
+
+// 日本語コメント: フロア形状をポリゴンに解決（mm座標、時計回り）
+export function polygonFromFloor(floor: FloorState): Vec2[] {
+  const k = (floor.shape?.kind ?? 'rect') as TemplateKind
+  const d: any = (floor.shape as any)?.data
+  return k === 'rect' ? outlineRect(d)
+    : k === 'l' ? outlineL(d)
+    : k === 'u' ? outlineU(d)
+    : k === 't' ? outlineT(d)
+    : outlinePoly(d)
+}
+
+// 日本語コメント: 矩形（任意多角形）プリズムのワイヤーフレームを生成
+// - 外周の上面/下面（水平線）
+// - 各頂点の立ち上がり（垂直線）
+// parapetMm が正の場合、上面は壁上端 + parapet 分だけ上げる
+export function buildPrismWire(poly: Vec2[], baseZmm: number, wallTopZmm: number, parapetMm = 0): Segment3D[] {
+  const n = poly.length
+  if (n < 3) return []
+  const topZ = wallTopZmm + Math.max(0, parapetMm)
+  const segs: Segment3D[] = []
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n
+    const vi = poly[i]
+    const vj = poly[j]
+    // 下面リング
+    segs.push({ a: { x: vi.x, y: vi.y, z: baseZmm }, b: { x: vj.x, y: vj.y, z: baseZmm } })
+    // 上面リング（壁上端 + パラペット）
+    segs.push({ a: { x: vi.x, y: vi.y, z: topZ }, b: { x: vj.x, y: vj.y, z: topZ } })
+    // 垂直
+    segs.push({ a: { x: vi.x, y: vi.y, z: baseZmm }, b: { x: vi.x, y: vi.y, z: topZ } })
+  }
+  return segs
+}
+
+// 日本語コメント: 単位変換（mm→m）。three.js では 1 = 1m として扱う。
+export function mmToM(v: number): number { return v / 1000 }
+
+// 日本語コメント: フロア情報からフラット屋根のプリズム線分を生成
+export function buildFlatRoofWireFromFloor(floor: FloorState): Segment3D[] {
+  const poly = polygonFromFloor(floor)
+  const base = floor.elevationMm
+  const wallTop = floor.elevationMm + floor.heightMm
+  // 日本語コメント: フラット屋根（outer footprint）のパラペット高さを探す（なければ0）
+  const ru = (Array.isArray(floor.roofUnits) ? floor.roofUnits : []).find(u => u && u.footprint?.kind === 'outer' && u.type === 'flat')
+  const parapet = Math.max(0, Number(ru?.parapetHeightMm ?? 0))
+  return buildPrismWire(poly, base, wallTop, parapet)
+}
+
+// 日本語コメント: フラット屋根のプリズムを「実線」「点線（パラペット立上り部分）」に分離して生成
+export function buildFlatRoofWireStyledFromFloor(floor: FloorState): { solid: Segment3D[]; dashed: Segment3D[] } {
+  const basePoly = polygonFromFloor(floor)
+  const n = basePoly.length
+  const base = floor.elevationMm
+  const wallTop = floor.elevationMm + floor.heightMm
+  const ru = (Array.isArray(floor.roofUnits) ? floor.roofUnits : []).find(u => u && u.footprint?.kind === 'outer' && u.type === 'flat')
+  const parapet = Math.max(0, Number(ru?.parapetHeightMm ?? 0))
+  const topZ = wallTop + parapet
+  const solid: Segment3D[] = []
+  const dashed: Segment3D[] = []
+  if (n < 3) return { solid, dashed }
+  // 日本語コメント: 軒の出が有効な場合は上端リング（天井／パラペット）は外周オフセットを使用
+  const eavePoly = applyEavesOffset(basePoly, floor, ru as any)
+  // 日本語コメント: per-edge オフセット距離を算出（floor と roof のオーバーライドを反映）
+  const nEdges = basePoly.length
+  const def = floor.eaves?.amountMm ?? 0
+  const perEdge = floor.eaves?.perEdge ?? {}
+  const override = (ru as any)?.eavesOverride ?? {}
+  const enabled = override.enabled ?? floor.eaves?.enabled ?? false
+  const distances: number[] = []
+  for (let i = 0; i < nEdges; i++) {
+    const ov = override.perEdge?.[i]
+    const de = perEdge[i]
+    const di = (ov ?? de ?? override.amountMm ?? floor.eaves?.amountMm ?? def) || 0
+    distances.push(enabled ? Math.max(0, di) : 0)
+  }
+  const area = signedAreaModel(basePoly)
+  const lines = buildOffsetLines(basePoly as any, distances, area)
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n
+    const vi = basePoly[i], vj = basePoly[j]
+    const ei = eavePoly[i], ej = eavePoly[j]
+    const { start, end } = adjustedSegmentEndpoints(lines as any, distances, i)
+    // 下面リング（実線）
+    solid.push({ a: { x: vi.x, y: vi.y, z: base }, b: { x: vj.x, y: vj.y, z: base } })
+    // 天井ライン（壁上端、高さ = wallTop）は常に実線（軒の出ありでも壁天端は壁外周）
+    solid.push({ a: { x: vi.x, y: vi.y, z: wallTop }, b: { x: vj.x, y: vj.y, z: wallTop } })
+    // パラペット上端（topZ）は点線（parapet>0の時のみ）。軒の出がある場合は 調整済み端点（start→end）に沿う
+    if (parapet > 0) {
+      dashed.push({ a: { x: start.x, y: start.y, z: topZ }, b: { x: end.x, y: end.y, z: topZ } })
+    }
+    // 垂直: 壁（ベース→壁上端）は実線、パラペット（壁上端→上端）は点線
+    if (wallTop > base) {
+      solid.push({ a: { x: vi.x, y: vi.y, z: base }, b: { x: vi.x, y: vi.y, z: wallTop } })
+    }
+    if (parapet > 0) {
+      // 日本語コメント: パラペット下端リングも eaves 調整端点（start→end）で点線として描画
+      dashed.push({ a: { x: start.x, y: start.y, z: wallTop }, b: { x: end.x, y: end.y, z: wallTop } })
+      // 日本語コメント: パラペットの立上りは軒の出オフセット端点で表現（start/end で両端）
+      dashed.push({ a: { x: start.x, y: start.y, z: wallTop }, b: { x: start.x, y: start.y, z: topZ } })
+      dashed.push({ a: { x: end.x, y: end.y, z: wallTop }, b: { x: end.x, y: end.y, z: topZ } })
+    }
+  }
+  return { solid, dashed }
+}
+
+// 日本語コメント: 線分群のバウンディングボックスを返す（mm）
+export function bboxOfSegments(segs: Segment3D[]): { min: Vec3; max: Vec3 } | null {
+  if (!segs.length) return null
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity, minZ = Infinity, maxZ = -Infinity
+  for (const s of segs) {
+    const pts = [s.a, s.b]
+    for (const p of pts) {
+      minX = Math.min(minX, p.x)
+      maxX = Math.max(maxX, p.x)
+      minY = Math.min(minY, p.y)
+      maxY = Math.max(maxY, p.y)
+      minZ = Math.min(minZ, p.z)
+      maxZ = Math.max(maxZ, p.z)
+    }
+  }
+  return { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ } }
+}


### PR DESCRIPTION
## 概要
- フェーズ4の先行実装として、平面図から矩形系テンプレート（Rect/L/U/T/自由多角形）の外周を用いた3Dワイヤーフレーム表示を追加しました。
- 屋根はフラット屋根に対応。パラペットの上下リングと立ち上がりを点線で表現し、軒の出（per-edge 含む）を3Dにも反映します。
- 操作性を改善（OrbitControls）。左ドラッグ: 回転、右ドラッグ: パン、中/ピンチ/ホイール: ズーム、Shift+ホイール: パン。

## 変更点
- 3Dビュー差し替え: `src/app/page.tsx` → `Wireframe3D` に変更
- 3D線画: `src/components/Wireframe3D.tsx` を追加
  - フロアごとに色分け、実線/点線を個別マテリアルで描画（LineBasicMaterial / LineDashedMaterial）
  - OrbitControlsで操作（ダンピングあり）、Shift+ホイールでパン（独自 panByPixels）
- 線分生成: `src/core/wireframe-3d.ts` を追加
  - フラット屋根: 天井ライン（実線）、パラペット上下リング＋立ち上がり（点線）
  - 軒の出: per-edge/overrideを反映し、ミター調整した外周で上端/下端リングと垂直を生成
  - L/U/T/自由多角形にも対応
- ログ: `activity.log` を追記

## スクリーンショット/メモ
- 3Dビューで、テンプレートを L/U/T に切替 → 形状が外周通りにワイヤーで表示
- 軒の出ON + フラット屋根（パラペット高さあり）→ 天井ライン=実線、パラペット（上下/立ち上がり）=点線

## 互換性/影響
- 既存の平面・立面機能に影響なし（3Dのみ差し替え）
- three, postprocessing は既存依存（新規追加なし）

## 今後の拡張（別PR想定）
- 切妻/寄棟/片流れの3D線画対応（軒の出反映）
- 隠線/破線ルールの最適化、線幅調整
- 3D UI（フィット/リセット/軸固定）
- エクスポート（PNG/SVG/GLB）

## チェックリスト
- [x] 動作確認（ズーム/回転/パン、L/U/T、軒の出/パラペット表示）
- [x] activity.log 追記
- [x] 既存機能への回帰影響なし
